### PR TITLE
TST: deactivate rich printing within testing for better reproducibility

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 packages_to_try = [
@@ -22,3 +24,9 @@ packages_to_try = [
 @pytest.fixture(params=packages_to_try)
 def package_name(request):
     return request.param
+
+
+def pytest_configure():
+    # minimal workaround to avoid false negatives when testing
+    # with rich installed.
+    os.environ.update({"COLUMNS": "180"})


### PR DESCRIPTION
I need to fix the case where pytest is invoked as `python -m pytest ...`