### PR TITLE
MNT: drop support for Python 3.6

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Install build dependencies
         run: python -m pip install build wheel
       - name: Build distributions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,10 @@ jobs:
           windows-latest,
         ]
         python-version: [
-          '3.6',
           '3.7',
           '3.8',
           '3.9',
-          '3.10-dev',
+          '3.10',
         ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,10 +14,9 @@ repos:
       - id: no-commit-to-branch
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.17.0
+    rev: v1.18.0
     hooks:
       - id: setup-cfg-fmt
-        args: ["--max-py-version", "3.10"]
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.10
@@ -25,7 +24,7 @@ repos:
         - id: remove-tabs
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.26.0
+    rev: v2.29.0
     hooks:
       - id: pyupgrade
         args: ["--py37-plus"]
@@ -36,7 +35,7 @@ repos:
         - id: reorder-python-imports
 
   - repo: https://github.com/psf/black
-    rev: 21.6b0
+    rev: 21.9b0
     hooks:
       - id: black
         language_version: python3
@@ -48,6 +47,6 @@ repos:
         additional_dependencies : ['flake8-bugbear==20.11.1']
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
+    rev: v0.910-1
     hooks:
       - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,12 @@ repos:
     hooks:
         - id: remove-tabs
 
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.26.0
+    hooks:
+      - id: pyupgrade
+        args: ["--py37-plus"]
+
   - repo: https://github.com/asottile/reorder_python_imports
     rev: v2.6.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,6 @@ its purpose.
 
 ## Notes
 
-- `wxc` is tested on macOS, Linux, and partially on Windows, from Python 3.6 to 3.10 (beta)
+- `wxc` is tested on macOS, Linux, and partially on Windows, from Python 3.7 to 3.10
 - this project was formerly named "whych" and renamed to avoid confusion with the
   pypi-available package of the same name.

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -27,7 +26,7 @@ install_requires =
     rich>=10.7.0
     importlib-metadata;python_version < "3.8"
     stdlib-list>=0.8;python_version < "3.10"
-python_requires = >=3.6
+python_requires = >=3.7
 
 [options.packages.find]
 exclude =
@@ -49,7 +48,7 @@ dev =
     numpy;python_version < "3.10"
 
 [mypy]
-python_version = 3.6
+python_version = 3.7
 warn_return_any = True
 warn_unused_configs = True
 

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 
 from wxc.api import get_obj
@@ -9,10 +7,6 @@ from wxc.cli import main
 TO_CHECK = frozenset(("os.fspath", "math.sqrt"))
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 7),
-    reason="This error message was changed in Python 3.7",
-)
 @pytest.mark.parametrize("name", TO_CHECK)
 def test_get_data_builtin(name):
     obj = get_obj(name)


### PR DESCRIPTION
I want to merge this once 3.10.0 is available via https://github.com/actions/python-versions