### PR TITLE
TST: broaden a test's assertions to allow diversity of outputs

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -148,7 +148,8 @@ def test_source_error(capsys):
     # rich may output an unspecified amount of newlines
     # that don't actually affect the result visually
     assert out.strip() == ""
-    assert err == "ERROR could not find class definition\n"
+    # the exact error message varies depending on the Python runtime, which is fine
+    assert err.startswith("ERROR")
     assert ret2 != 0
 
 


### PR DESCRIPTION
I see this test failing with uv-installed Python 3.13, though the error message I get is still reasonable. I shouldn't be testing stuff I do not control.